### PR TITLE
Asynchrony more explicit

### DIFF
--- a/Kotlin/src/Listing_04.kt
+++ b/Kotlin/src/Listing_04.kt
@@ -1,27 +1,24 @@
 import kotlinx.coroutines.*
 
 fun main() = runBlocking {
-    val j1 = fibonacciCoroutine(40)
+    val j1 = async { fibonacciCoroutine(40) }
     println("1")
-    val j2 = fibonacciCoroutine(45)
+    val j2 = async { fibonacciCoroutine(45) }
     println("2")
-    j1.join()
-    j2.join()
+    println("fib(40) = ${j1.await()}")
+    println("fib(45) = ${j2.await()}")
     println("Fertig")
 }
 
-fun fibonacciCoroutine(n: Int): Job {
-    return GlobalScope.launch {
-        println("Berechne fib($n)")
-        println("fib($n) = ${fibonacci(n)}")
-    }
+suspend fun fibonacciCoroutine(n: Int) = withContext(Dispatchers.Default) {
+    println("Berechne fib($n)")
+    fibonacci(n)
 }
 
 fun fibonacci(n: Int): Int {
-    if (n <= 1) {
-        return n
+    return if (n <= 1) {
+        n
     } else {
-        return fibonacci(n - 1) +
-                fibonacci(n - 2)
+        fibonacci(n - 1) + fibonacci(n - 2)
     }
 }

--- a/Kotlin/src/Listing_04.kt
+++ b/Kotlin/src/Listing_04.kt
@@ -1,16 +1,16 @@
 import kotlinx.coroutines.*
 
 fun main() = runBlocking {
-    val j1 = async { fibonacciCoroutine(40) }
+    val j1 = async { calcFibonacci(40) }
     println("1")
-    val j2 = async { fibonacciCoroutine(45) }
+    val j2 = async { calcFibonacci(45) }
     println("2")
     println("fib(40) = ${j1.await()}")
     println("fib(45) = ${j2.await()}")
     println("Fertig")
 }
 
-suspend fun fibonacciCoroutine(n: Int) = withContext(Dispatchers.Default) {
+suspend fun calcFibonacci(n: Int) = withContext(Dispatchers.Default) {
     println("Berechne fib($n)")
     fibonacci(n)
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# mind_the_thread
-Concurrency and asynchronicity in programming languages
+test


### PR DESCRIPTION
Hi Thomas,

I changed this example a bit. 
1. Using `async` makes the whole code more explicit IMO because you can see that the  `calcFibonacci` function works asynchronously. I also moved the logging of the result into `main` because the `await` now returns the fibonacci calculation result.
2. In the original example, you used `GlobalScope`, which is okay but not optimal because this uses detached threads that are not associated the the original coroutine anymore. If you would cancel the outer `runBlocking`, this cancellation would not be delegated to the `launch` coroutines. With the change, this will be the case since `async` is invoked inside `runBlocking`s scope. In order to still achieve the parallel execution of all `calcFibonacci` calls, I used `withContext` to dispatch the task on the default dispatcher pool (otherwise, although `async` is used, everything would run on the Dispatcher of `runBlocking`, which is the main thread in this example).

PS: `fibonacciCoroutine` was no coroutine anymore, I changed the name accordingly. 